### PR TITLE
chore: remove unnecessary reqwest module from bedrock

### DIFF
--- a/llm/bedrock/Cargo.toml
+++ b/llm/bedrock/Cargo.toml
@@ -27,10 +27,6 @@ golem-llm = { workspace = true }
 
 golem-rust = { workspace = true }
 log = { workspace = true }
-reqwest = { git = "https://github.com/golemcloud/reqwest", branch = "update-july-2025", features = [
-    "json",
-    "async",
-] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wit-bindgen-rt = { workspace = true }

--- a/llm/bedrock/src/wasi_client.rs
+++ b/llm/bedrock/src/wasi_client.rs
@@ -8,8 +8,7 @@ use aws_smithy_runtime_api::{
     http::{Headers, Response, StatusCode},
 };
 use aws_smithy_types::body::SdkBody;
-use reqwest::Method;
-use wstd::http;
+use wstd::http::{self, Method};
 
 use crate::async_utils::UnsafeFuture;
 


### PR DESCRIPTION
After switching to `wstd`, I don't need to use the `Method` type from reqwest anymore since `wstd` has it's own exposed type.

This PR removes `reqwest` as a dependency of aws bedrock