### PR TITLE
feature(llm): add provider options passthrough

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,6 +222,7 @@ jobs:
           golem agent invoke 'test:llm/llm-test("ollama-1")' test6 | grep -v "ERROR: "
           golem agent invoke 'test:llm/llm-test("ollama-1")' test7 | grep -v "ERROR: "
           golem agent invoke 'test:llm/llm-test("ollama-1")' test8 | grep -v "ERROR: "
+          golem agent invoke 'test:llm/llm-test("ollama-1")' test9 | grep -v "ERROR: "
 
   graph-integration-tests:
     runs-on: ubuntu-latest

--- a/llm/README.md
+++ b/llm/README.md
@@ -41,7 +41,8 @@ with the underlying LLM provider.
 
 ## Examples
 
-Take the [test application](../test/llm/components-rust/test-llm/src/lib.rs) as an example of using `golem-llm` from Rust. 
+Take the [test application](../test/llm/components-rust/test-llm/src/lib.rs) as an example of using `golem-llm` from
+Rust.
 The implemented test functions are demonstrating the following:
 
 | Function Name | Description                                                                                |
@@ -53,7 +54,8 @@ The implemented test functions are demonstrating the following:
 | `test5`       | Using an image in the prompt                                                               |
 | `test6`       | Demonstrates that the streaming response is continued in case of a crash (with Golem only) |
 | `test7`       | Using a source image by passing byte array as base64 in the prompt                         |
-| `test8`       | Multi-turn conversation with streaming                                                      |
+| `test8`       | Multi-turn conversation with streaming                                                     |
+| `test9`       | Provider-options passthrough smoke test (provider-specific extra parameters)               |
 
 ### Running the examples
 
@@ -62,20 +64,20 @@ binary started with `golem server run`.
 
 Then build and deploy the _test application_. The following profiles are available for testing:
 
-| Profile Name         | Description                                                                           |
-|----------------------|---------------------------------------------------------------------------------------|
-| `anthropic-debug`    | Uses the Anthropic LLM implementation and compiles the code in debug profile          |
-| `anthropic-release`  | Uses the Anthropic LLM implementation and compiles the code in release profile        |
-| `ollama-debug`       | Uses the Ollama LLM implementation and compiles the code in debug profile             |
-| `ollama-release`     | Uses the Ollama LLM implementation and compiles the code in release profile           |
-| `grok-debug`         | Uses the Grok LLM implementation and compiles the code in debug profile               |
-| `grok-release`       | Uses the Grok LLM implementation and compiles the code in release profile             |
-| `openai-debug`       | Uses the OpenAI LLM implementation and compiles the code in debug profile             |
-| `openai-release`     | Uses the OpenAI LLM implementation and compiles the code in release profile           |
-| `openrouter-debug`   | Uses the OpenRouter LLM implementation and compiles the code in debug profile         |
-| `openrouter-release` | Uses the OpenRouter LLM implementation and compiles the code in release profile       |
-| `bedrock-debug`      | Uses the Amazon Bedrock LLM implementation and compiles the code in debug profile     |
-| `bedrock-release`    | Uses the Amazon Bedrock LLM implementation and compiles the code in release profile   |
+| Profile Name         | Description                                                                         |
+|----------------------|-------------------------------------------------------------------------------------|
+| `anthropic-debug`    | Uses the Anthropic LLM implementation and compiles the code in debug profile        |
+| `anthropic-release`  | Uses the Anthropic LLM implementation and compiles the code in release profile      |
+| `ollama-debug`       | Uses the Ollama LLM implementation and compiles the code in debug profile           |
+| `ollama-release`     | Uses the Ollama LLM implementation and compiles the code in release profile         |
+| `grok-debug`         | Uses the Grok LLM implementation and compiles the code in debug profile             |
+| `grok-release`       | Uses the Grok LLM implementation and compiles the code in release profile           |
+| `openai-debug`       | Uses the OpenAI LLM implementation and compiles the code in debug profile           |
+| `openai-release`     | Uses the OpenAI LLM implementation and compiles the code in release profile         |
+| `openrouter-debug`   | Uses the OpenRouter LLM implementation and compiles the code in debug profile       |
+| `openrouter-release` | Uses the OpenRouter LLM implementation and compiles the code in release profile     |
+| `bedrock-debug`      | Uses the Amazon Bedrock LLM implementation and compiles the code in debug profile   |
+| `bedrock-release`    | Uses the Amazon Bedrock LLM implementation and compiles the code in release profile |
 
 ```bash
 cd ../test/llm
@@ -83,7 +85,8 @@ golem build --preset openai-debug
 golem deploy --preset openai-debug --yes
 ```
 
-Depending on the provider selected, an environment variable has to be set for the worker to be started, containing the ENVIRONMENT variable (eg.API key) for the given provider:
+Depending on the provider selected, an environment variable has to be set for the worker to be started, containing the
+ENVIRONMENT variable (eg.API key) for the given provider:
 
 ```bash
 golem agent  new test:llm/debug --env OPENAI_API_KEY=xxx --env GOLEM_LLM_LOG=trace
@@ -94,6 +97,3 @@ Then you can invoke the test functions on this worker:
 ```bash
 golem agent  invoke test:llm/debug test1 --stream 
 ```
-
-
-

--- a/llm/anthropic/src/client.rs
+++ b/llm/anthropic/src/client.rs
@@ -7,6 +7,7 @@ use log::trace;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 const BASE_URL: &str = "https://api.anthropic.com";
@@ -84,6 +85,8 @@ pub struct MessagesRequest {
     pub top_k: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_params: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/llm/anthropic/src/conversions.rs
+++ b/llm/anthropic/src/conversions.rs
@@ -5,20 +5,14 @@ use crate::client::{
 use base64::{engine::general_purpose, Engine as _};
 use golem_ai_llm::model::{
     Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageReference, ImageSource,
-    ImageUrl, Response, ResponseMetadata, Role, ToolCall, ToolDefinition, ToolResult, Usage,
+    ImageUrl, Kv, Response, ResponseMetadata, Role, ToolCall, ToolDefinition, ToolResult, Usage,
 };
 use std::collections::HashMap;
 
 pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<MessagesRequest, Error> {
-    let options = config
-        .provider_options
-        .map(|options| {
-            options
-                .into_iter()
-                .map(|kv| (kv.key, kv.value))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
+    let provider_options = config.provider_options.clone();
+    let options = provider_options_to_string_map(provider_options.clone());
+    let mut additional_params = provider_options_to_json_map(provider_options);
 
     let (user_messages, system_messages) = events_to_messages_and_system_messages(events);
 
@@ -35,27 +29,62 @@ pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<MessagesR
         })
         .transpose()?;
 
+    let metadata = options
+        .get("user_id")
+        .map(|user_id| MessagesRequestMetadata {
+            user_id: Some(user_id.to_string()),
+        });
+    let stop_sequences = config.stop_sequences;
+    let temperature = config.temperature;
+    let top_k = options
+        .get("top_k")
+        .and_then(|top_k_s| top_k_s.parse::<u32>().ok());
+    let top_p = options
+        .get("top_p")
+        .and_then(|top_p_s| top_p_s.parse::<f32>().ok());
+
+    if metadata.is_some() {
+        additional_params.remove("user_id");
+    }
+    if stop_sequences.is_some() {
+        additional_params.remove("stop_sequences");
+    }
+    if temperature.is_some() {
+        additional_params.remove("temperature");
+    }
+    if tool_choice.is_some() {
+        additional_params.remove("tool_choice");
+    }
+    if tools.is_some() {
+        additional_params.remove("tools");
+    }
+    if top_k.is_some() {
+        additional_params.remove("top_k");
+    }
+    if top_p.is_some() {
+        additional_params.remove("top_p");
+    }
+
+    additional_params.remove("max_tokens");
+    additional_params.remove("messages");
+    additional_params.remove("model");
+    additional_params.remove("stream");
+    additional_params.remove("system");
+
     Ok(MessagesRequest {
         max_tokens: config.max_tokens.unwrap_or(4096),
         messages: user_messages,
         model: config.model,
-        metadata: options
-            .get("user_id")
-            .map(|user_id| MessagesRequestMetadata {
-                user_id: Some(user_id.to_string()),
-            }),
-        stop_sequences: config.stop_sequences,
+        metadata,
+        stop_sequences,
         stream: false,
         system: system_messages,
-        temperature: config.temperature,
+        temperature,
         tool_choice,
         tools,
-        top_k: options
-            .get("top_k")
-            .and_then(|top_k_s| top_k_s.parse::<u32>().ok()),
-        top_p: options
-            .get("top_p")
-            .and_then(|top_p_s| top_p_s.parse::<f32>().ok()),
+        top_k,
+        top_p,
+        additional_params,
     })
 }
 
@@ -299,5 +328,90 @@ fn tool_definition_to_tool(tool: ToolDefinition) -> Result<Tool, Error> {
             message: format!("Failed to parse tool parameters for {}: {error}", tool.name),
             provider_error_json: None,
         }),
+    }
+}
+
+fn provider_options_to_string_map(provider_options: Option<Vec<Kv>>) -> HashMap<String, String> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, kv.value))
+        .collect::<HashMap<_, _>>()
+}
+
+fn provider_options_to_json_map(
+    provider_options: Option<Vec<Kv>>,
+) -> HashMap<String, serde_json::Value> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, parse_provider_option_value(&kv.value)))
+        .collect::<HashMap<_, _>>()
+}
+
+fn parse_provider_option_value(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_ai_llm::model::{Config, Kv};
+
+    fn kv(key: &str, value: &str) -> Kv {
+        Kv {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    fn base_config(provider_options: Option<Vec<Kv>>) -> Config {
+        Config {
+            model: "claude-test".to_string(),
+            temperature: Some(0.5),
+            max_tokens: Some(128),
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            provider_options,
+        }
+    }
+
+    #[test]
+    fn forwards_unmapped_provider_options() {
+        let request = events_to_request(
+            Vec::new(),
+            base_config(Some(vec![
+                kv("user_id", "u1"),
+                kv("top_k", "50"),
+                kv("custom_mode", "\"json\""),
+            ])),
+        )
+        .unwrap();
+
+        assert_eq!(
+            request.metadata.and_then(|metadata| metadata.user_id),
+            Some("u1".to_string())
+        );
+        assert_eq!(request.top_k, Some(50));
+        assert_eq!(
+            request.additional_params.get("custom_mode"),
+            Some(&serde_json::json!("json"))
+        );
+        assert!(!request.additional_params.contains_key("user_id"));
+        assert!(!request.additional_params.contains_key("top_k"));
+    }
+
+    #[test]
+    fn keeps_known_option_when_typed_parse_fails() {
+        let request =
+            events_to_request(Vec::new(), base_config(Some(vec![kv("top_p", "adaptive")])))
+                .unwrap();
+
+        assert_eq!(request.top_p, None);
+        assert_eq!(
+            request.additional_params.get("top_p"),
+            Some(&serde_json::json!("adaptive"))
+        );
     }
 }

--- a/llm/bedrock/src/conversions.rs
+++ b/llm/bedrock/src/conversions.rs
@@ -27,16 +27,7 @@ impl BedrockInput {
         events: Vec<llm::Event>,
     ) -> Result<Self, llm::Error> {
         let (user_messages, system_instructions) = events_to_bedrock_message_groups(events).await?;
-
-        let options = config
-            .provider_options
-            .map(|options| {
-                options
-                    .into_iter()
-                    .map(|kv| (kv.key, Document::String(kv.value)))
-                    .collect::<HashMap<_, _>>()
-            })
-            .unwrap_or_default();
+        let options = provider_options_to_additional_fields(config.provider_options);
 
         Ok(BedrockInput {
             model_id: config.model.clone(),
@@ -46,6 +37,9 @@ impl BedrockInput {
                 .set_stop_sequences(config.stop_sequences.clone())
                 .set_top_p(options.get("top_p").and_then(|v| match v {
                     Document::String(v) => v.parse::<f32>().ok(),
+                    Document::Number(Number::Float(v)) => Some(*v as f32),
+                    Document::Number(Number::NegInt(v)) => Some(*v as f32),
+                    Document::Number(Number::PosInt(v)) => Some(*v as f32),
                     _ => None,
                 }))
                 .build(),
@@ -55,6 +49,31 @@ impl BedrockInput {
             additional_fields: Document::Object(options),
         })
     }
+}
+
+fn provider_options_to_additional_fields(
+    provider_options: Option<Vec<llm::Kv>>,
+) -> HashMap<String, Document> {
+    provider_options_to_json_map(provider_options)
+        .into_iter()
+        .fold(HashMap::new(), |mut acc, (key, value)| {
+            acc.insert(key, serde_json_to_smithy_document(value));
+            acc
+        })
+}
+
+fn provider_options_to_json_map(
+    provider_options: Option<Vec<llm::Kv>>,
+) -> HashMap<String, serde_json::Value> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, parse_provider_option_value(&kv.value)))
+        .collect::<HashMap<_, _>>()
+}
+
+fn parse_provider_option_value(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
 }
 
 fn tool_defs_to_bedrock_tool_config(
@@ -619,4 +638,37 @@ pub fn merge_metadata(
         .or(metadata2.provider_metadata_json);
 
     metadata1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kv(key: &str, value: &str) -> llm::Kv {
+        llm::Kv {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn provider_options_support_non_string_values() {
+        let fields = provider_options_to_additional_fields(Some(vec![
+            kv("top_p", "0.95"),
+            kv("enabled", "true"),
+            kv("metadata", "{\"tier\":\"pro\"}"),
+            kv("tag", "preview"),
+        ]));
+
+        match fields.get("top_p") {
+            Some(Document::Number(Number::Float(value))) => assert!((*value - 0.95).abs() < 0.0001),
+            other => panic!("unexpected top_p value: {other:?}"),
+        }
+        assert!(matches!(fields.get("enabled"), Some(Document::Bool(true))));
+        assert!(matches!(fields.get("metadata"), Some(Document::Object(_))));
+        assert!(matches!(
+            fields.get("tag"),
+            Some(Document::String(value)) if value == "preview"
+        ));
+    }
 }

--- a/llm/grok/src/client.rs
+++ b/llm/grok/src/client.rs
@@ -6,6 +6,7 @@ use golem_wasi_http::{Client, Method, Response};
 use log::trace;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str::FromStr;
 
@@ -95,6 +96,8 @@ pub struct CompletionsRequest {
     pub top_p: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_params: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/llm/grok/src/conversions.rs
+++ b/llm/grok/src/conversions.rs
@@ -1,21 +1,15 @@
 use crate::client::{CompletionsRequest, CompletionsResponse, Detail, Effort};
 use base64::{engine::general_purpose, Engine as _};
 use golem_ai_llm::model::{
-    Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageDetail, ImageReference,
+    Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageDetail, ImageReference, Kv,
     Response, ResponseMetadata, Role, ToolCall, ToolDefinition, ToolResult, Usage,
 };
 use std::collections::HashMap;
 
 pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<CompletionsRequest, Error> {
-    let options = config
-        .provider_options
-        .map(|options| {
-            options
-                .into_iter()
-                .map(|kv| (kv.key, kv.value))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
+    let provider_options = config.provider_options.clone();
+    let options = provider_options_to_string_map(provider_options.clone());
+    let mut additional_params = provider_options_to_json_map(provider_options);
 
     let mut completion_messages = Vec::new();
     for event in events {
@@ -69,36 +63,94 @@ pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<Completio
         tools.push(tool_definition_to_tool(tool)?)
     }
 
+    let frequency_penalty = options
+        .get("frequency_penalty")
+        .and_then(|fp_s| fp_s.parse::<f32>().ok());
+    let n = options.get("n").and_then(|n_s| n_s.parse::<u32>().ok());
+    let presence_penalty = options
+        .get("presence_penalty")
+        .and_then(|pp_s| pp_s.parse::<f32>().ok());
+    let reasoning_effort = options
+        .get("reasoning_effort")
+        .and_then(|effort_s| effort_s.parse::<Effort>().ok());
+    let seed = options
+        .get("seed")
+        .and_then(|seed_s| seed_s.parse::<u32>().ok());
+    let stop = config.stop_sequences;
+    let temperature = config.temperature;
+    let tool_choice = config.tool_choice;
+    let top_logprobs = options
+        .get("top_logprobs")
+        .and_then(|top_logprobs_s| top_logprobs_s.parse::<u8>().ok());
+    let top_p = options
+        .get("top_p")
+        .and_then(|top_p_s| top_p_s.parse::<f32>().ok());
+    let user = options.get("user_id").cloned();
+
+    if frequency_penalty.is_some() {
+        additional_params.remove("frequency_penalty");
+    }
+    if n.is_some() {
+        additional_params.remove("n");
+    }
+    if presence_penalty.is_some() {
+        additional_params.remove("presence_penalty");
+    }
+    if reasoning_effort.is_some() {
+        additional_params.remove("reasoning_effort");
+    }
+    if seed.is_some() {
+        additional_params.remove("seed");
+    }
+    if stop.is_some() {
+        additional_params.remove("stop");
+    }
+    if temperature.is_some() {
+        additional_params.remove("temperature");
+    }
+    if tool_choice.is_some() {
+        additional_params.remove("tool_choice");
+    }
+    if top_logprobs.is_some() {
+        additional_params.remove("top_logprobs");
+    }
+    if top_p.is_some() {
+        additional_params.remove("top_p");
+    }
+    if user.is_some() {
+        additional_params.remove("user_id");
+    }
+    if !tools.is_empty() {
+        additional_params.remove("tools");
+    }
+    if config.max_tokens.is_some() {
+        additional_params.remove("max_completion_tokens");
+    }
+
+    additional_params.remove("messages");
+    additional_params.remove("model");
+    additional_params.remove("stream");
+    additional_params.remove("stream_options");
+
     Ok(CompletionsRequest {
         messages: completion_messages,
         model: config.model,
-        frequency_penalty: options
-            .get("frequency_penalty")
-            .and_then(|fp_s| fp_s.parse::<f32>().ok()),
+        frequency_penalty,
         max_completion_tokens: config.max_tokens,
-        n: options.get("n").and_then(|n_s| n_s.parse::<u32>().ok()),
-        presence_penalty: options
-            .get("presence_penalty")
-            .and_then(|pp_s| pp_s.parse::<f32>().ok()),
-        reasoning_effort: options
-            .get("reasoning_effort")
-            .and_then(|effort_s| effort_s.parse::<Effort>().ok()),
-        seed: options
-            .get("seed")
-            .and_then(|seed_s| seed_s.parse::<u32>().ok()),
-        stop: config.stop_sequences,
+        n,
+        presence_penalty,
+        reasoning_effort,
+        seed,
+        stop,
         stream: Some(false),
         stream_options: None,
-        temperature: config.temperature,
-        tool_choice: config.tool_choice,
+        temperature,
+        tool_choice,
         tools,
-        top_logprobs: options
-            .get("top_logprobs")
-            .and_then(|top_logprobs_s| top_logprobs_s.parse::<u8>().ok()),
-        top_p: options
-            .get("top_p")
-            .and_then(|top_p_s| top_p_s.parse::<f32>().ok()),
-        user: options.get("user_id").cloned(),
+        top_logprobs,
+        top_p,
+        user,
+        additional_params,
     })
 }
 
@@ -258,5 +310,83 @@ fn tool_definition_to_tool(tool: ToolDefinition) -> Result<crate::client::Tool, 
             message: format!("Failed to parse tool parameters for {}: {error}", tool.name),
             provider_error_json: None,
         }),
+    }
+}
+
+fn provider_options_to_string_map(provider_options: Option<Vec<Kv>>) -> HashMap<String, String> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, kv.value))
+        .collect::<HashMap<_, _>>()
+}
+
+fn provider_options_to_json_map(
+    provider_options: Option<Vec<Kv>>,
+) -> HashMap<String, serde_json::Value> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, parse_provider_option_value(&kv.value)))
+        .collect::<HashMap<_, _>>()
+}
+
+fn parse_provider_option_value(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_ai_llm::model::{Config, Kv};
+
+    fn kv(key: &str, value: &str) -> Kv {
+        Kv {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    fn base_config(provider_options: Option<Vec<Kv>>) -> Config {
+        Config {
+            model: "grok-test".to_string(),
+            temperature: Some(0.1),
+            max_tokens: Some(48),
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            provider_options,
+        }
+    }
+
+    #[test]
+    fn forwards_unmapped_provider_options() {
+        let request = events_to_request(
+            Vec::new(),
+            base_config(Some(vec![kv("user_id", "alice"), kv("custom_depth", "3")])),
+        )
+        .unwrap();
+
+        assert_eq!(request.user, Some("alice".to_string()));
+        assert!(!request.additional_params.contains_key("user_id"));
+        assert_eq!(
+            request.additional_params.get("custom_depth"),
+            Some(&serde_json::json!(3))
+        );
+    }
+
+    #[test]
+    fn keeps_option_when_typed_parse_fails() {
+        let request = events_to_request(
+            Vec::new(),
+            base_config(Some(vec![kv("top_logprobs", "many")])),
+        )
+        .unwrap();
+
+        assert_eq!(request.top_logprobs, None);
+        assert_eq!(
+            request.additional_params.get("top_logprobs"),
+            Some(&serde_json::json!("many"))
+        );
     }
 }

--- a/llm/ollama/src/client.rs
+++ b/llm/ollama/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, fs, path::Path};
+use std::{collections::HashMap, fmt::Debug, fs, path::Path};
 
 use base64::{engine::general_purpose, Engine};
 use golem_ai_llm::{
@@ -145,6 +145,8 @@ pub struct OllamaModelOptions {
     pub use_mmap: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_thread: Option<i32>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_params: HashMap<String, serde_json::Value>,
 }
 
 /// ChatRequest is parameters for a request to the chat endpoint
@@ -176,6 +178,8 @@ pub struct CompletionsRequest {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_alive: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_params: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/llm/ollama/src/conversions.rs
+++ b/llm/ollama/src/conversions.rs
@@ -5,22 +5,45 @@ use crate::client::{
 };
 use base64::{engine::general_purpose, Engine};
 use golem_ai_llm::model::{
-    Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageReference, Message, Response,
-    ResponseMetadata, Role, ToolCall as GolemToolCall, ToolResult, Usage,
+    Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageReference, Kv, Message,
+    Response, ResponseMetadata, Role, ToolCall as GolemToolCall, ToolResult, Usage,
 };
 use log::trace;
 use std::collections::HashMap;
 
 pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<CompletionsRequest, Error> {
-    let options = config
-        .provider_options
-        .map(|options| {
-            options
-                .into_iter()
-                .map(|kv| (kv.key, kv.value))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
+    let provider_options = config.provider_options.clone();
+    let options = provider_options_to_string_map(provider_options.clone());
+    let mut option_additional_params = provider_options_to_json_map(provider_options);
+    let mut request_additional_params = HashMap::new();
+
+    if let Some(serde_json::Value::Object(object)) = option_additional_params.remove("options") {
+        for (key, value) in object {
+            option_additional_params.insert(key, value);
+        }
+    }
+
+    let option_prefixed_keys = option_additional_params
+        .keys()
+        .filter(|key| key.starts_with("options."))
+        .cloned()
+        .collect::<Vec<_>>();
+    for key in option_prefixed_keys {
+        if let Some(value) = option_additional_params.remove(&key) {
+            option_additional_params.insert(key.trim_start_matches("options.").to_string(), value);
+        }
+    }
+
+    let request_prefixed_keys = option_additional_params
+        .keys()
+        .filter(|key| key.starts_with("request."))
+        .cloned()
+        .collect::<Vec<_>>();
+    for key in request_prefixed_keys {
+        if let Some(value) = option_additional_params.remove(&key) {
+            request_additional_params.insert(key.trim_start_matches("request.").to_string(), value);
+        }
+    }
 
     let mut request_messages = Vec::new();
 
@@ -51,41 +74,165 @@ pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<Completio
         });
     }
 
+    let min_p = parse_option(&options, "min_p");
+    let top_p = parse_option(&options, "top_p");
+    let top_k = parse_option(&options, "top_k");
+    let num_predict = parse_option(&options, "num_predict");
+    let stop = config.stop_sequences.clone();
+    let repeat_penalty = parse_option(&options, "repeat_penalty");
+    let num_ctx = parse_option(&options, "num_ctx");
+    let seed = parse_option(&options, "seed");
+    let mirostat = parse_option(&options, "mirostat");
+    let mirostat_eta = parse_option(&options, "mirostat_eta");
+    let mirostat_tau = parse_option(&options, "mirostat_tau");
+    let num_gpu = parse_option(&options, "num_gpu");
+    let num_thread = parse_option(&options, "num_thread");
+    let penalize_newline = parse_option(&options, "penalize_newline");
+    let num_keep = parse_option(&options, "num_keep");
+    let typical_p = parse_option(&options, "typical_p");
+    let repeat_last_n = parse_option(&options, "repeat_last_n");
+    let presence_penalty = parse_option(&options, "presence_penalty");
+    let frequency_penalty = parse_option(&options, "frequency_penalty");
+    let numa = parse_option(&options, "numa");
+    let num_batch = parse_option(&options, "num_batch");
+    let main_gpu = parse_option(&options, "main_gpu");
+    let use_mmap = parse_option(&options, "use_mmap");
+    let format = options.get("format").cloned();
+    let keep_alive = options.get("keep_alive").cloned();
+
+    if min_p.is_some() {
+        option_additional_params.remove("min_p");
+    }
+    if top_p.is_some() {
+        option_additional_params.remove("top_p");
+    }
+    if top_k.is_some() {
+        option_additional_params.remove("top_k");
+    }
+    if num_predict.is_some() {
+        option_additional_params.remove("num_predict");
+    }
+    if stop.is_some() {
+        option_additional_params.remove("stop");
+    }
+    if repeat_penalty.is_some() {
+        option_additional_params.remove("repeat_penalty");
+    }
+    if num_ctx.is_some() {
+        option_additional_params.remove("num_ctx");
+    }
+    if seed.is_some() {
+        option_additional_params.remove("seed");
+    }
+    if mirostat.is_some() {
+        option_additional_params.remove("mirostat");
+    }
+    if mirostat_eta.is_some() {
+        option_additional_params.remove("mirostat_eta");
+    }
+    if mirostat_tau.is_some() {
+        option_additional_params.remove("mirostat_tau");
+    }
+    if num_gpu.is_some() {
+        option_additional_params.remove("num_gpu");
+    }
+    if num_thread.is_some() {
+        option_additional_params.remove("num_thread");
+    }
+    if penalize_newline.is_some() {
+        option_additional_params.remove("penalize_newline");
+    }
+    if num_keep.is_some() {
+        option_additional_params.remove("num_keep");
+    }
+    if typical_p.is_some() {
+        option_additional_params.remove("typical_p");
+    }
+    if repeat_last_n.is_some() {
+        option_additional_params.remove("repeat_last_n");
+    }
+    if presence_penalty.is_some() {
+        option_additional_params.remove("presence_penalty");
+    }
+    if frequency_penalty.is_some() {
+        option_additional_params.remove("frequency_penalty");
+    }
+    if numa.is_some() {
+        option_additional_params.remove("numa");
+    }
+    if num_batch.is_some() {
+        option_additional_params.remove("num_batch");
+    }
+    if main_gpu.is_some() {
+        option_additional_params.remove("main_gpu");
+    }
+    if use_mmap.is_some() {
+        option_additional_params.remove("use_mmap");
+    }
+    if config.temperature.is_some() {
+        option_additional_params.remove("temperature");
+    }
+
+    if format.is_some() {
+        option_additional_params.remove("format");
+        request_additional_params.remove("format");
+    }
+    if keep_alive.is_some() {
+        option_additional_params.remove("keep_alive");
+        request_additional_params.remove("keep_alive");
+    }
+
+    option_additional_params.remove("model");
+    option_additional_params.remove("messages");
+    option_additional_params.remove("tools");
+    option_additional_params.remove("stream");
+    option_additional_params.remove("keep_alive");
+    option_additional_params.remove("format");
+    option_additional_params.remove("options");
+
+    request_additional_params.remove("model");
+    request_additional_params.remove("messages");
+    request_additional_params.remove("tools");
+    request_additional_params.remove("stream");
+    request_additional_params.remove("options");
+
     let ollama_options = OllamaModelOptions {
-        min_p: parse_option(&options, "min_p"),
+        min_p,
         temperature: config.temperature,
-        top_p: parse_option(&options, "top_p"),
-        top_k: parse_option(&options, "top_k"),
-        num_predict: parse_option(&options, "num_predict"),
-        stop: config.stop_sequences.clone(),
-        repeat_penalty: parse_option(&options, "repeat_penalty"),
-        num_ctx: parse_option(&options, "num_ctx"),
-        seed: parse_option(&options, "seed"),
-        mirostat: parse_option(&options, "mirostat"),
-        mirostat_eta: parse_option(&options, "mirostat_eta"),
-        mirostat_tau: parse_option(&options, "mirostat_tau"),
-        num_gpu: parse_option(&options, "num_gpu"),
-        num_thread: parse_option(&options, "num_thread"),
-        penalize_newline: parse_option(&options, "penalize_newline"),
-        num_keep: parse_option(&options, "num_keep"),
-        typical_p: parse_option(&options, "typical_p"),
-        repeat_last_n: parse_option(&options, "repeat_last_n"),
-        presence_penalty: parse_option(&options, "presence_penalty"),
-        frequency_penalty: parse_option(&options, "frequency_penalty"),
-        numa: parse_option(&options, "numa"),
-        num_batch: parse_option(&options, "num_batch"),
-        main_gpu: parse_option(&options, "main_gpu"),
-        use_mmap: parse_option(&options, "use_mmap"),
+        top_p,
+        top_k,
+        num_predict,
+        stop,
+        repeat_penalty,
+        num_ctx,
+        seed,
+        mirostat,
+        mirostat_eta,
+        mirostat_tau,
+        num_gpu,
+        num_thread,
+        penalize_newline,
+        num_keep,
+        typical_p,
+        repeat_last_n,
+        presence_penalty,
+        frequency_penalty,
+        numa,
+        num_batch,
+        main_gpu,
+        use_mmap,
+        additional_params: option_additional_params,
     };
 
     Ok(CompletionsRequest {
         model: Some(config.model.clone()),
         messages: Some(request_messages),
         tools: Some(tools),
-        format: options.get("format").map(|v| v.to_string()),
+        format,
         options: Some(ollama_options),
-        keep_alive: options.get("keep_alive").map(|v| v.to_string()),
+        keep_alive,
         stream: Some(false),
+        additional_params: request_additional_params,
     })
 }
 
@@ -298,4 +445,92 @@ pub fn get_provider_metadata(response: &CompletionsResponse) -> String {
         response.eval_duration.unwrap_or(0),
         response.eval_count.unwrap_or(0)
     )
+}
+
+fn provider_options_to_string_map(provider_options: Option<Vec<Kv>>) -> HashMap<String, String> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, kv.value))
+        .collect::<HashMap<_, _>>()
+}
+
+fn provider_options_to_json_map(
+    provider_options: Option<Vec<Kv>>,
+) -> HashMap<String, serde_json::Value> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, parse_provider_option_value(&kv.value)))
+        .collect::<HashMap<_, _>>()
+}
+
+fn parse_provider_option_value(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_ai_llm::model::{Config, Kv};
+
+    fn kv(key: &str, value: &str) -> Kv {
+        Kv {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    fn base_config(provider_options: Option<Vec<Kv>>) -> Config {
+        Config {
+            model: "ollama-test".to_string(),
+            temperature: Some(0.4),
+            max_tokens: None,
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            provider_options,
+        }
+    }
+
+    #[test]
+    fn forwards_unmapped_options_inside_ollama_options() {
+        let request = events_to_request(
+            Vec::new(),
+            base_config(Some(vec![
+                kv("top_p", "0.8"),
+                kv("new_sampling_mode", "\"aggressive\""),
+                kv("format", "json"),
+                kv("request.raw", "true"),
+            ])),
+        )
+        .unwrap();
+
+        assert_eq!(request.format, Some("json".to_string()));
+        assert_eq!(
+            request.additional_params.get("raw"),
+            Some(&serde_json::json!(true))
+        );
+
+        let options = request.options.expect("options should be present");
+        assert_eq!(options.top_p, Some(0.8));
+        assert_eq!(
+            options.additional_params.get("new_sampling_mode"),
+            Some(&serde_json::json!("aggressive"))
+        );
+        assert!(!options.additional_params.contains_key("top_p"));
+    }
+
+    #[test]
+    fn keeps_known_option_when_typed_parse_fails() {
+        let request =
+            events_to_request(Vec::new(), base_config(Some(vec![kv("num_ctx", "large")]))).unwrap();
+
+        let options = request.options.expect("options should be present");
+        assert_eq!(options.num_ctx, None);
+        assert_eq!(
+            options.additional_params.get("num_ctx"),
+            Some(&serde_json::json!("large"))
+        );
+    }
 }

--- a/llm/openai/src/client.rs
+++ b/llm/openai/src/client.rs
@@ -6,6 +6,7 @@ use golem_wasi_http::{Client, Method, Response};
 use log::trace;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 const BASE_URL: &str = "https://api.openai.com/v1";
@@ -91,6 +92,8 @@ pub struct CreateModelResponseRequest {
     pub top_p: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_params: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/llm/openai/src/conversions.rs
+++ b/llm/openai/src/conversions.rs
@@ -5,8 +5,8 @@ use crate::client::{
 use base64::{engine::general_purpose, Engine as _};
 use golem_ai_llm::error::error_code_from_status;
 use golem_ai_llm::model::{
-    Config, ContentPart, Error, ErrorCode, Event, ImageDetail, ImageReference, Message, Response,
-    ResponseMetadata, Role, ToolCall, ToolDefinition, ToolResult, Usage,
+    Config, ContentPart, Error, ErrorCode, Event, ImageDetail, ImageReference, Kv, Message,
+    Response, ResponseMetadata, Role, ToolCall, ToolDefinition, ToolResult, Usage,
 };
 use golem_wasi_http::StatusCode;
 use log::trace;
@@ -18,15 +18,35 @@ pub fn create_request(
     config: Config,
     tools: Vec<Tool>,
 ) -> CreateModelResponseRequest {
-    let options = config
-        .provider_options
-        .map(|options| {
-            options
-                .into_iter()
-                .map(|kv| (kv.key, kv.value))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
+    let provider_options = config.provider_options.clone();
+    let options = provider_options_to_string_map(provider_options.clone());
+    let mut additional_params = provider_options_to_json_map(provider_options);
+
+    let top_p = options
+        .get("top_p")
+        .and_then(|top_p_s| top_p_s.parse::<f32>().ok());
+    let user = options.get("user").cloned();
+
+    if top_p.is_some() {
+        additional_params.remove("top_p");
+    }
+    if user.is_some() {
+        additional_params.remove("user");
+    }
+    if config.temperature.is_some() {
+        additional_params.remove("temperature");
+    }
+    if config.max_tokens.is_some() {
+        additional_params.remove("max_output_tokens");
+    }
+    if config.tool_choice.is_some() {
+        additional_params.remove("tool_choice");
+    }
+
+    additional_params.remove("input");
+    additional_params.remove("model");
+    additional_params.remove("tools");
+    additional_params.remove("stream");
 
     CreateModelResponseRequest {
         input: Input::List(items),
@@ -36,12 +56,9 @@ pub fn create_request(
         tools,
         tool_choice: config.tool_choice,
         stream: false,
-        top_p: options
-            .get("top_p")
-            .and_then(|top_p_s| top_p_s.parse::<f32>().ok()),
-        user: options
-            .get("user")
-            .and_then(|user_s| user_s.parse::<String>().ok()),
+        top_p,
+        user,
+        additional_params,
     }
 }
 
@@ -275,5 +292,91 @@ pub fn create_response_metadata(response: &CreateModelResponseResponse) -> Respo
         provider_id: Some(response.id.clone()),
         timestamp: Some(response.created_at.to_string()),
         provider_metadata_json: response.metadata.as_ref().map(|m| m.to_string()),
+    }
+}
+
+fn provider_options_to_string_map(provider_options: Option<Vec<Kv>>) -> HashMap<String, String> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, kv.value))
+        .collect::<HashMap<_, _>>()
+}
+
+fn provider_options_to_json_map(
+    provider_options: Option<Vec<Kv>>,
+) -> HashMap<String, serde_json::Value> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, parse_provider_option_value(&kv.value)))
+        .collect::<HashMap<_, _>>()
+}
+
+fn parse_provider_option_value(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_ai_llm::model::{Config, Kv};
+
+    fn kv(key: &str, value: &str) -> Kv {
+        Kv {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    fn base_config(provider_options: Option<Vec<Kv>>) -> Config {
+        Config {
+            model: "gpt-test".to_string(),
+            temperature: Some(0.7),
+            max_tokens: Some(128),
+            stop_sequences: None,
+            tools: None,
+            tool_choice: Some("auto".to_string()),
+            provider_options,
+        }
+    }
+
+    #[test]
+    fn includes_unmapped_provider_options_as_passthrough() {
+        let request = create_request(
+            Vec::new(),
+            base_config(Some(vec![
+                kv("top_p", "0.9"),
+                kv("custom_flag", "true"),
+                kv("custom_payload", "{\"mode\":\"fast\"}"),
+            ])),
+            Vec::new(),
+        );
+
+        assert_eq!(request.top_p, Some(0.9));
+        assert_eq!(
+            request.additional_params.get("custom_flag"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(
+            request.additional_params.get("custom_payload"),
+            Some(&serde_json::json!({"mode":"fast"}))
+        );
+        assert!(!request.additional_params.contains_key("top_p"));
+    }
+
+    #[test]
+    fn keeps_known_option_as_passthrough_when_typed_parse_fails() {
+        let request = create_request(
+            Vec::new(),
+            base_config(Some(vec![kv("top_p", "high")])),
+            Vec::new(),
+        );
+
+        assert_eq!(request.top_p, None);
+        assert_eq!(
+            request.additional_params.get("top_p"),
+            Some(&serde_json::json!("high"))
+        );
     }
 }

--- a/llm/openrouter/src/client.rs
+++ b/llm/openrouter/src/client.rs
@@ -6,6 +6,7 @@ use golem_wasi_http::{Client, Method, Response, StatusCode};
 use log::trace;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 const BASE_URL: &str = "https://openrouter.ai";
@@ -92,6 +93,8 @@ pub struct CompletionsRequest {
     pub min_p: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_a: Option<f32>,
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_params: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/llm/openrouter/src/conversions.rs
+++ b/llm/openrouter/src/conversions.rs
@@ -3,21 +3,15 @@ use crate::client::{
 };
 use base64::{engine::general_purpose, Engine as _};
 use golem_ai_llm::model::{
-    Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageDetail, ImageReference,
+    Config, ContentPart, Error, ErrorCode, Event, FinishReason, ImageDetail, ImageReference, Kv,
     Response, ResponseMetadata, Role, ToolCall, ToolDefinition, ToolResult, Usage,
 };
 use std::collections::HashMap;
 
 pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<CompletionsRequest, Error> {
-    let options = config
-        .provider_options
-        .map(|options| {
-            options
-                .into_iter()
-                .map(|kv| (kv.key, kv.value))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
+    let provider_options = config.provider_options.clone();
+    let options = provider_options_to_string_map(provider_options.clone());
+    let mut additional_params = provider_options_to_json_map(provider_options);
 
     let mut completion_messages = Vec::new();
     for event in events {
@@ -69,39 +63,96 @@ pub fn events_to_request(events: Vec<Event>, config: Config) -> Result<Completio
         tools.push(tool_definition_to_tool(tool)?)
     }
 
+    let frequency_penalty = options
+        .get("frequency_penalty")
+        .and_then(|fp_s| fp_s.parse::<f32>().ok());
+    let presence_penalty = options
+        .get("presence_penalty")
+        .and_then(|pp_s| pp_s.parse::<f32>().ok());
+    let repetition_penalty = options
+        .get("repetition_penalty")
+        .and_then(|rp_s| rp_s.parse::<f32>().ok());
+    let seed = options
+        .get("seed")
+        .and_then(|seed_s| seed_s.parse::<u32>().ok());
+    let stop = config.stop_sequences;
+    let temperature = config.temperature;
+    let tool_choice = config.tool_choice.map(convert_tool_choice);
+    let top_p = options
+        .get("top_p")
+        .and_then(|top_p_s| top_p_s.parse::<f32>().ok());
+    let top_k = options
+        .get("top_k")
+        .and_then(|top_k_s| top_k_s.parse::<f32>().ok());
+    let min_p = options
+        .get("min_p")
+        .and_then(|min_p_s| min_p_s.parse::<f32>().ok());
+    let top_a = options
+        .get("top_a")
+        .and_then(|top_a_s| top_a_s.parse::<f32>().ok());
+
+    if frequency_penalty.is_some() {
+        additional_params.remove("frequency_penalty");
+    }
+    if presence_penalty.is_some() {
+        additional_params.remove("presence_penalty");
+    }
+    if repetition_penalty.is_some() {
+        additional_params.remove("repetition_penalty");
+    }
+    if seed.is_some() {
+        additional_params.remove("seed");
+    }
+    if stop.is_some() {
+        additional_params.remove("stop");
+    }
+    if temperature.is_some() {
+        additional_params.remove("temperature");
+    }
+    if tool_choice.is_some() {
+        additional_params.remove("tool_choice");
+    }
+    if top_p.is_some() {
+        additional_params.remove("top_p");
+    }
+    if top_k.is_some() {
+        additional_params.remove("top_k");
+    }
+    if min_p.is_some() {
+        additional_params.remove("min_p");
+    }
+    if top_a.is_some() {
+        additional_params.remove("top_a");
+    }
+    if !tools.is_empty() {
+        additional_params.remove("tools");
+    }
+    if config.max_tokens.is_some() {
+        additional_params.remove("max_tokens");
+    }
+
+    additional_params.remove("messages");
+    additional_params.remove("model");
+    additional_params.remove("stream");
+
     Ok(CompletionsRequest {
         messages: completion_messages,
         model: config.model,
-        frequency_penalty: options
-            .get("frequency_penalty")
-            .and_then(|fp_s| fp_s.parse::<f32>().ok()),
+        frequency_penalty,
         max_tokens: config.max_tokens,
-        presence_penalty: options
-            .get("presence_penalty")
-            .and_then(|pp_s| pp_s.parse::<f32>().ok()),
-        repetition_penalty: options
-            .get("repetition_penalty")
-            .and_then(|rp_s| rp_s.parse::<f32>().ok()),
-        seed: options
-            .get("seed")
-            .and_then(|seed_s| seed_s.parse::<u32>().ok()),
-        stop: config.stop_sequences,
+        presence_penalty,
+        repetition_penalty,
+        seed,
+        stop,
         stream: Some(false),
-        temperature: config.temperature,
-        tool_choice: config.tool_choice.map(convert_tool_choice),
+        temperature,
+        tool_choice,
         tools,
-        top_p: options
-            .get("top_p")
-            .and_then(|top_p_s| top_p_s.parse::<f32>().ok()),
-        top_k: options
-            .get("top_k")
-            .and_then(|top_k_s| top_k_s.parse::<f32>().ok()),
-        min_p: options
-            .get("min_p")
-            .and_then(|min_p_s| min_p_s.parse::<f32>().ok()),
-        top_a: options
-            .get("top_a")
-            .and_then(|top_a_s| top_a_s.parse::<f32>().ok()),
+        top_p,
+        top_k,
+        min_p,
+        top_a,
+        additional_params,
     })
 }
 
@@ -271,5 +322,83 @@ fn convert_tool_choice(tool_choice: String) -> crate::client::ToolChoice {
         _ => crate::client::ToolChoice::Function(ToolChoiceFunction::Function {
             function: FunctionName { name: tool_choice },
         }),
+    }
+}
+
+fn provider_options_to_string_map(provider_options: Option<Vec<Kv>>) -> HashMap<String, String> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, kv.value))
+        .collect::<HashMap<_, _>>()
+}
+
+fn provider_options_to_json_map(
+    provider_options: Option<Vec<Kv>>,
+) -> HashMap<String, serde_json::Value> {
+    provider_options
+        .unwrap_or_default()
+        .into_iter()
+        .map(|kv| (kv.key, parse_provider_option_value(&kv.value)))
+        .collect::<HashMap<_, _>>()
+}
+
+fn parse_provider_option_value(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use golem_ai_llm::model::{Config, Kv};
+
+    fn kv(key: &str, value: &str) -> Kv {
+        Kv {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    fn base_config(provider_options: Option<Vec<Kv>>) -> Config {
+        Config {
+            model: "openrouter-test".to_string(),
+            temperature: Some(0.2),
+            max_tokens: Some(64),
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            provider_options,
+        }
+    }
+
+    #[test]
+    fn includes_unmapped_options_in_passthrough_map() {
+        let request = events_to_request(
+            Vec::new(),
+            base_config(Some(vec![
+                kv("frequency_penalty", "0.1"),
+                kv("experimental", "{\"reasoning\":true}"),
+            ])),
+        )
+        .unwrap();
+
+        assert_eq!(request.frequency_penalty, Some(0.1));
+        assert!(!request.additional_params.contains_key("frequency_penalty"));
+        assert_eq!(
+            request.additional_params.get("experimental"),
+            Some(&serde_json::json!({"reasoning": true}))
+        );
+    }
+
+    #[test]
+    fn keeps_failed_typed_parsing_as_passthrough() {
+        let request =
+            events_to_request(Vec::new(), base_config(Some(vec![kv("top_p", "rapid")]))).unwrap();
+
+        assert_eq!(request.top_p, None);
+        assert_eq!(
+            request.additional_params.get("top_p"),
+            Some(&serde_json::json!("rapid"))
+        );
     }
 }

--- a/test/golem-temp/generated-base-wit/test_llm/deps/test_llm-exports/exports.wit
+++ b/test/golem-temp/generated-base-wit/test_llm/deps/test_llm-exports/exports.wit
@@ -9,6 +9,7 @@ interface test-llm-api {
   test6: func() -> string;
   test7: func() -> string;
   test8: func() -> string;
+  test9: func() -> string;
 }
 
 interface test-llm-inline-functions {}

--- a/test/llm/components-rust/test-llm/src/lib.rs
+++ b/test/llm/components-rust/test-llm/src/lib.rs
@@ -69,6 +69,66 @@ const IMAGE_MODEL: &str = "openrouter/auto";
 #[cfg(feature = "ollama")]
 const IMAGE_MODEL: &str = "gemma3:4b";
 
+#[cfg(feature = "openai")]
+fn provider_passthrough_options() -> Vec<Kv> {
+    vec![
+        Kv {
+            key: "max_output_tokens".to_string(),
+            value: "64".to_string(),
+        },
+        Kv {
+            key: "store".to_string(),
+            value: "false".to_string(),
+        },
+    ]
+}
+
+#[cfg(feature = "anthropic")]
+fn provider_passthrough_options() -> Vec<Kv> {
+    vec![Kv {
+        key: "metadata".to_string(),
+        value: r#"{"user_id":"passthrough-test","session":"golem-ai"}"#.to_string(),
+    }]
+}
+
+#[cfg(feature = "grok")]
+fn provider_passthrough_options() -> Vec<Kv> {
+    vec![Kv {
+        key: "max_completion_tokens".to_string(),
+        value: "64".to_string(),
+    }]
+}
+
+#[cfg(feature = "openrouter")]
+fn provider_passthrough_options() -> Vec<Kv> {
+    vec![
+        Kv {
+            key: "max_tokens".to_string(),
+            value: "64".to_string(),
+        },
+        Kv {
+            key: "models".to_string(),
+            value: "[\"openai/gpt-4o-mini\"]".to_string(),
+        },
+    ]
+}
+
+#[cfg(feature = "ollama")]
+fn provider_passthrough_options() -> Vec<Kv> {
+    vec![Kv {
+        key: "options".to_string(),
+        value: r#"{"use_mlock":true}"#.to_string(),
+    }]
+}
+
+#[cfg(feature = "bedrock")]
+fn provider_passthrough_options() -> Vec<Kv> {
+    vec![Kv {
+        key: "top_k".to_string(),
+        value: "20".to_string(),
+    }]
+}
+
 #[agent_definition]
 pub trait LlmTest {
     fn new(name: String) -> Self;
@@ -81,6 +141,7 @@ pub trait LlmTest {
     async fn test6(&self) -> String;
     fn test7(&self) -> String;
     async fn test8(&self) -> String;
+    fn test9(&self) -> String;
 }
 
 struct LlmTestImpl {
@@ -708,5 +769,58 @@ impl LlmTest for LlmTestImpl {
         }
 
         result
+    }
+
+    fn test9(&self) -> String {
+        let config = Config {
+            model: MODEL.to_string(),
+            temperature: Some(0.1),
+            max_tokens: None,
+            stop_sequences: None,
+            tools: None,
+            tool_choice: None,
+            provider_options: Some(provider_passthrough_options()),
+        };
+
+        println!(
+            "Sending request with passthrough options: {:?}",
+            config.provider_options
+        );
+
+        let response = Provider::send(
+            vec![Event::Message(Message {
+                role: Role::User,
+                name: None,
+                content: vec![ContentPart::Text(
+                    "Reply with the text: passthrough-ok".to_string(),
+                )],
+            })],
+            config,
+        );
+
+        match response {
+            Ok(response) => {
+                let text = response
+                    .content
+                    .into_iter()
+                    .filter_map(|part| match part {
+                        ContentPart::Text(value) => Some(value),
+                        ContentPart::Image(_) => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
+                format!(
+                    "content={text}; metadata={:?}; tool_calls={:?}",
+                    response.metadata, response.tool_calls
+                )
+            }
+            Err(error) => format!(
+                "ERROR: {:?} {} ({})",
+                error.code,
+                error.message,
+                error.provider_error_json.unwrap_or_default()
+            ),
+        }
     }
 }


### PR DESCRIPTION
This PR adds generic provider-options passthrough for LLM providers so new upstream parameters can be forwarded without code changes per parameter.

The implementation keeps the existing typed option handling, but also forwards unknown/unmapped options upstream directly as JSON values.

Fixes: #110