### PR TITLE
fix: rewrite durability-off passthroughs as native Rust trait passthroughs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "golem-rust"
-version = "2.0.0-dev.8"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4188bacbe44825cbd3da6c01c9915350377d97d32bc7737f7abb59c39a5986"
+checksum = "3ea024a64286f601153573384530faa23b665b628b81eb27b2c204b0e93d6141"
 dependencies = [
  "golem-rust-macro",
  "golem-wasm",
@@ -2338,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "golem-rust-macro"
-version = "2.0.0-dev.8"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2dd6dece3e268292cbf75320bb64ee5911b8ab7dc3bd9a52e0fa1e10c43449"
+checksum = "3d01cd51a38737e1431ede857b99cc2955731c02960f56663d0c830541d72170"
 dependencies = [
  "heck 0.5.0",
  "humantime",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -83,7 +83,12 @@ end
 # Maintenance tasks
 [tasks.check]
 description = "Runs rustfmt and clippy checks without applying any fix"
-dependencies = ["check-clippy", "check-rustfmt"]
+dependencies = [
+    "check-clippy",
+    "check-clippy-no-default-features",
+    "check-clippy-no-default-features-exec",
+    "check-rustfmt",
+]
 
 [tasks.check-rustfmt]
 description = "Runs rustfmt checks without applying any fix"
@@ -96,6 +101,63 @@ description = "Runs clippy checks without applying any fix"
 install_crate = "clippy"
 command = "cargo"
 args = ["clippy", "--all-targets", "--", "--no-deps", "-Dwarnings"]
+
+[tasks.check-clippy-no-default-features]
+description = "Runs clippy with --no-default-features across the workspace. The `stt` and `llm` crate families are excluded because their passthrough-path fix lives in separate PRs; drop the --exclude flags once those merge. The `exec` crate has non-durability feature requirements and is handled by check-clippy-no-default-features-exec."
+install_crate = "clippy"
+command = "cargo"
+args = [
+    "clippy",
+    "--workspace",
+    "--no-default-features",
+    "--exclude",
+    "golem-ai-stt",
+    "--exclude",
+    "golem-ai-stt-whisper",
+    "--exclude",
+    "golem-ai-stt-aws",
+    "--exclude",
+    "golem-ai-stt-azure",
+    "--exclude",
+    "golem-ai-stt-deepgram",
+    "--exclude",
+    "golem-ai-stt-google",
+    "--exclude",
+    "golem-ai-llm",
+    "--exclude",
+    "golem-ai-llm-openai",
+    "--exclude",
+    "golem-ai-llm-anthropic",
+    "--exclude",
+    "golem-ai-llm-grok",
+    "--exclude",
+    "golem-ai-llm-ollama",
+    "--exclude",
+    "golem-ai-llm-openrouter",
+    "--exclude",
+    "golem-ai-llm-bedrock",
+    "--exclude",
+    "golem-ai-exec",
+    "--",
+    "--no-deps",
+    "-Dwarnings",
+]
+
+[tasks.check-clippy-no-default-features-exec]
+description = "Runs clippy on golem-ai-exec with --no-default-features --features 'javascript python'. The `exec` crate's non-durability features (javascript, python) are required for meaningful compilation; bundling everything into a single --no-default-features check disables them too and produces unrelated dead-code warnings."
+install_crate = "clippy"
+command = "cargo"
+args = [
+    "clippy",
+    "-p",
+    "golem-ai-exec",
+    "--no-default-features",
+    "--features",
+    "javascript python",
+    "--",
+    "--no-deps",
+    "-Dwarnings",
+]
 
 [tasks.fix]
 description = "Runs rustfmt and clippy checks and applies fixes"

--- a/embed/embed/src/durability.rs
+++ b/embed/embed/src/durability.rs
@@ -9,13 +9,13 @@ pub struct DurableEmbed<Impl> {
 /// Trait to be implemented in addition to the embed `EmbeddingProvider` trait when wrapping it with durability.
 pub trait ExtendedEmbeddingProvider: EmbeddingProvider + 'static {}
 
-/// When the durability feature flag is off, wrapping with `DurableEmbed` is just a passthrough
+/// When the durability feature flag is off, `DurableEmbed<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use crate::durability::{DurableEmbed, ExtendedEmbeddingProvider};
-    use crate::golem::embed::embed::{
-        Config, ContentPart, EmbeddingProvider, EmbeddingResponse, Error, RerankResponse,
-    };
+    use crate::model::{Config, ContentPart, EmbeddingResponse, Error, RerankResponse};
+    use crate::EmbeddingProvider;
 
     impl<Impl: ExtendedEmbeddingProvider> EmbeddingProvider for DurableEmbed<Impl> {
         fn generate(inputs: Vec<ContentPart>, config: Config) -> Result<EmbeddingResponse, Error> {

--- a/exec/exec/src/durability.rs
+++ b/exec/exec/src/durability.rs
@@ -20,22 +20,26 @@ pub trait SessionSnapshot<Session> {
 #[derive(Debug, Clone, IntoValue, FromValueAndType)]
 pub struct EmptySnapshot {}
 
-/// When the durability feature flag is off, wrapping with `DurableLLM` is just a passthrough
+/// When the durability feature flag is off, `DurableExec<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use crate::durability::DurableExec;
-    use crate::golem::exec::executor::{Error, ExecResult, File, Guest, Language, RunOptions};
+    use crate::model::{Error, ExecResult, File, Language, RunOptions};
+    use crate::ExecutionProvider;
+    use async_trait::async_trait;
 
-    impl<Impl: Guest> Guest for DurableExec<Impl> {
+    #[async_trait(?Send)]
+    impl<Impl: ExecutionProvider + 'static> ExecutionProvider for DurableExec<Impl> {
         type Session = Impl::Session;
 
-        fn run(
+        async fn run(
             lang: Language,
             modules: Vec<File>,
             snippet: String,
             options: RunOptions,
         ) -> Result<ExecResult, Error> {
-            Impl::run(lang, modules, snippet, options)
+            Impl::run(lang, modules, snippet, options).await
         }
     }
 }

--- a/graph/graph/src/durability.rs
+++ b/graph/graph/src/durability.rs
@@ -2,7 +2,6 @@ use crate::model::{
     connection::{self, ConnectionConfig},
     errors::GraphError,
     schema::SchemaManager,
-    transactions::{self},
 };
 use crate::{GraphInterface, TransactionInterface};
 use std::marker::PhantomData;
@@ -27,13 +26,15 @@ pub trait ProviderGraph: GraphInterface {
     type Transaction: TransactionInterface;
 }
 
-/// When the durability feature flag is off, wrapping with `DurableGraph` is just a passthrough
+/// When the durability feature flag is off, `DurableGraph<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use super::*;
     use crate::init_logging;
+    use crate::{GraphProvider, SchemaManagerProvider, TransactionProvider};
 
-    impl<Impl: ExtendedGuest> connection::Guest for DurableGraph<Impl>
+    impl<Impl: ExtendedGuest> GraphProvider for DurableGraph<Impl>
     where
         Impl::Graph: ProviderGraph + 'static,
     {
@@ -46,14 +47,14 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedGuest + TransactionGuest> TransactionGuest for DurableGraph<Impl>
+    impl<Impl: ExtendedGuest + TransactionProvider> TransactionProvider for DurableGraph<Impl>
     where
         Impl::Graph: ProviderGraph + 'static,
     {
         type Transaction = Impl::Transaction;
     }
 
-    impl<Impl: ExtendedGuest + SchemaGuest> SchemaGuest for DurableGraph<Impl>
+    impl<Impl: ExtendedGuest + SchemaManagerProvider> SchemaManagerProvider for DurableGraph<Impl>
     where
         Impl::Graph: ProviderGraph + 'static,
     {
@@ -71,14 +72,14 @@ mod passthrough_impl {
 #[cfg(feature = "durability")]
 mod durable_impl {
     use super::*;
-    use crate::durability::transactions::CreateVertexOptions;
     use crate::model::connection::GraphStatistics;
+    use crate::model::transactions;
     use crate::model::transactions::{
-        CreateEdgeOptions, Edge, ElementId, ExecuteQueryOptions, FindAllPathsOptions,
-        FindEdgesOptions, FindShortestPathOptions, FindVerticesOptions, GetAdjacentVerticesOptions,
-        GetConnectedEdgesOptions, GetNeighborhoodOptions, GetVerticesAtDistanceOptions, Path,
-        PathExistsOptions, QueryExecutionResult, Subgraph, UpdateEdgeOptions, UpdateVertexOptions,
-        Vertex,
+        CreateEdgeOptions, CreateVertexOptions, Edge, ElementId, ExecuteQueryOptions,
+        FindAllPathsOptions, FindEdgesOptions, FindShortestPathOptions, FindVerticesOptions,
+        GetAdjacentVerticesOptions, GetConnectedEdgesOptions, GetNeighborhoodOptions,
+        GetVerticesAtDistanceOptions, Path, PathExistsOptions, QueryExecutionResult, Subgraph,
+        UpdateEdgeOptions, UpdateVertexOptions, Vertex,
     };
     use crate::{
         init_logging, GraphInterface, GraphProvider, SchemaManagerProvider, TransactionInterface,

--- a/search/search/src/durability.rs
+++ b/search/search/src/durability.rs
@@ -30,18 +30,19 @@ pub trait ExtendedSearchProvider: SearchProvider + 'static {
     fn subscribe(stream: &Self::SearchStream) -> Pollable;
 }
 
-/// When the durability feature flag is off, wrapping with `DurableSearch` is just a passthrough
+/// When the durability feature flag is off, `DurableSearch<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use crate::durability::{DurableSearch, ExtendedSearchProvider};
     use crate::init_logging;
     use crate::model::{
         CreateIndexOptions, Doc, DocumentId, IndexName, Schema, SearchError, SearchQuery,
-        SearchResults,
+        SearchResults, SearchStream,
     };
-    use crate::model::{Guest, SearchStream};
+    use crate::SearchProvider;
 
-    impl<Impl: ExtendedSearchProvider> Guest for DurableSearch<Impl> {
+    impl<Impl: ExtendedSearchProvider> SearchProvider for DurableSearch<Impl> {
         type SearchStream = Impl::SearchStream;
 
         fn create_index(options: CreateIndexOptions) -> Result<(), SearchError> {

--- a/tts/tts/src/durability.rs
+++ b/tts/tts/src/durability.rs
@@ -40,28 +40,22 @@ pub trait ExtendedTtsProvider:
     ) -> golem_rust::golem_wasm::Pollable;
 }
 
-/// When the durability feature flag is off, wrapping with `DurableTts` is just a passthrough
+/// When the durability feature flag is off, `DurableTts<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use crate::durability::{DurableTts, ExtendedTtsProvider};
     use crate::init_logging;
-    use crate::model::advanced::Guest as AdvancedGuest;
     use crate::model::advanced::{
-        AudioSample, LongFormOperation, LongFormResult, OperationStatus, PronunciationEntry,
-        PronunciationLexicon, VoiceDesignParams,
+        AudioSample, LongFormOperation, PronunciationEntry, PronunciationLexicon, VoiceDesignParams,
     };
-    use crate::model::streaming::Guest as StreamingGuest;
-    use crate::model::streaming::{StreamStatus, SynthesisStream, VoiceConversionStream};
-    use crate::model::synthesis::Guest as SynthesisGuest;
+    use crate::model::streaming::{SynthesisStream, VoiceConversionStream};
     use crate::model::synthesis::{SynthesisOptions, ValidationResult};
-    use crate::model::types::{
-        AudioChunk, AudioConfig, AudioEffects, AudioFormat, LanguageCode, SynthesisResult,
-        TextInput, TimingInfo, TtsError, VoiceGender, VoiceQuality, VoiceSettings,
-    };
-    use crate::model::voices::Guest as VoicesGuest;
+    use crate::model::types::{LanguageCode, SynthesisResult, TextInput, TimingInfo, TtsError};
     use crate::model::voices::{LanguageInfo, Voice, VoiceFilter, VoiceInfo, VoiceResults};
+    use crate::{AdvancedTtsProvider, StreamingVoiceProvider, SynthesizeProvider, VoiceProvider};
 
-    impl<Impl: ExtendedTtsProvider> VoicesGuest for DurableTts<Impl> {
+    impl<Impl: ExtendedTtsProvider> VoiceProvider for DurableTts<Impl> {
         type Voice = Impl::Voice;
         type VoiceResults = Impl::VoiceResults;
 
@@ -86,7 +80,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedTtsProvider> SynthesisGuest for DurableTts<Impl> {
+    impl<Impl: ExtendedTtsProvider> SynthesizeProvider for DurableTts<Impl> {
         fn synthesize(
             input: TextInput,
             voice: crate::model::voices::VoiceBorrow<'_>,
@@ -122,7 +116,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedTtsProvider> StreamingGuest for DurableTts<Impl> {
+    impl<Impl: ExtendedTtsProvider> StreamingVoiceProvider for DurableTts<Impl> {
         type SynthesisStream = Impl::SynthesisStream;
         type VoiceConversionStream = Impl::VoiceConversionStream;
 
@@ -143,7 +137,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedTtsProvider> AdvancedGuest for DurableTts<Impl> {
+    impl<Impl: ExtendedTtsProvider> AdvancedTtsProvider for DurableTts<Impl> {
         type PronunciationLexicon = Impl::PronunciationLexicon;
         type LongFormOperation = Impl::LongFormOperation;
 

--- a/vector/vector/src/durability.rs
+++ b/vector/vector/src/durability.rs
@@ -20,13 +20,18 @@ impl<T: ExtendedVectorProvider> FuncProvider for T {
     type FilterFunc = crate::model::types::FilterExpression;
 }
 
-/// When the durability feature flag is off, wrapping with `DurableVector` is just a passthrough
+/// When the durability feature flag is off, `DurableVector<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use super::*;
     use crate::init_logging;
+    use crate::{
+        AnalyticsProvider, CollectionProvider, ConnectionProvider, NamespacesProvider,
+        SearchExtendedProvider, SearchProvider, VectorsProvider,
+    };
 
-    impl<Impl: ExtendedVectorProvider + ConnectionGuest> ConnectionGuest for DurableVector<Impl> {
+    impl<Impl: ExtendedVectorProvider + ConnectionProvider> ConnectionProvider for DurableVector<Impl> {
         fn connect(
             endpoint: String,
             credentials: Option<crate::model::connection::Credentials>,
@@ -59,7 +64,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVectorProvider + CollectionsGuest> CollectionsGuest for DurableVector<Impl> {
+    impl<Impl: ExtendedVectorProvider + CollectionProvider> CollectionProvider for DurableVector<Impl> {
         fn upsert_collection(
             name: String,
             description: Option<String>,
@@ -104,7 +109,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVectorProvider + VectorsGuest> VectorsGuest for DurableVector<Impl> {
+    impl<Impl: ExtendedVectorProvider + VectorsProvider> VectorsProvider for DurableVector<Impl> {
         fn upsert_vectors(
             collection: String,
             vectors: Vec<crate::model::types::VectorRecord>,
@@ -217,7 +222,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVectorProvider + SearchGuest> SearchGuest for DurableVector<Impl> {
+    impl<Impl: ExtendedVectorProvider + SearchProvider> SearchProvider for DurableVector<Impl> {
         fn search_vectors(
             collection: String,
             query: crate::model::search::SearchQuery,
@@ -279,7 +284,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVectorProvider + SearchExtendedGuest> SearchExtendedGuest
+    impl<Impl: ExtendedVectorProvider + SearchExtendedProvider> SearchExtendedProvider
         for DurableVector<Impl>
     {
         fn recommend_vectors(
@@ -392,7 +397,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVectorProvider + AnalyticsGuest> AnalyticsGuest for DurableVector<Impl> {
+    impl<Impl: ExtendedVectorProvider + AnalyticsProvider> AnalyticsProvider for DurableVector<Impl> {
         fn get_collection_stats(
             collection: String,
             namespace: Option<String>,
@@ -421,7 +426,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVectorProvider + NamespacesGuest> NamespacesGuest for DurableVector<Impl> {
+    impl<Impl: ExtendedVectorProvider + NamespacesProvider> NamespacesProvider for DurableVector<Impl> {
         fn upsert_namespace(
             collection: String,
             namespace: String,
@@ -455,11 +460,6 @@ mod passthrough_impl {
             init_logging();
             Impl::namespace_exists(collection, namespace)
         }
-    }
-
-    impl<Impl: ExtendedVectorProvider> crate::model::types::Guest for DurableVector<Impl> {
-        type MetadataFunc = crate::model::types::MetadataValue;
-        type FilterFunc = crate::model::types::FilterExpression;
     }
 }
 

--- a/vector/vector/src/durability.rs
+++ b/vector/vector/src/durability.rs
@@ -20,6 +20,11 @@ impl<T: ExtendedVectorProvider> FuncProvider for T {
     type FilterFunc = crate::model::types::FilterExpression;
 }
 
+impl<Impl: ExtendedVectorProvider> FuncProvider for DurableVector<Impl> {
+    type MetadataFunc = crate::model::types::MetadataValue;
+    type FilterFunc = crate::model::types::FilterExpression;
+}
+
 /// When the durability feature flag is off, `DurableVector<Impl>` is a transparent wrapper that
 /// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
@@ -1822,11 +1827,6 @@ mod durable_impl {
         field: String,
         limit: Option<u32>,
         namespace: Option<String>,
-    }
-
-    impl<Impl: ExtendedVectorProvider> FuncProvider for DurableVector<Impl> {
-        type MetadataFunc = crate::model::types::MetadataValue;
-        type FilterFunc = crate::model::types::FilterExpression;
     }
 }
 

--- a/video/video/src/durability.rs
+++ b/video/video/src/durability.rs
@@ -1,8 +1,3 @@
-#[allow(unused_imports)]
-use crate::model::types::{
-    AudioSource, BaseVideo, EffectType, GenerationConfig, InputImage, Kv, LipSyncVideo, MediaInput,
-    VideoError, VideoResult, VoiceInfo,
-};
 use crate::{AdvancedVideoGenerationProvider, LipSyncProvider, VideoGenerationProvider};
 use std::marker::PhantomData;
 
@@ -11,28 +6,28 @@ pub struct DurableVideo<Impl> {
     phantom: PhantomData<Impl>,
 }
 
-/// Trait to be implemented in addition to the Video `Guest` traits when wrapping it with `DurableVideo`.
+/// Trait implemented by provider crates in addition to the three native Video provider traits
+/// so `DurableVideo` can be parameterised by a single type that supplies all of them.
 pub trait ExtendedVideoGenerationProvider:
     VideoGenerationProvider + LipSyncProvider + AdvancedVideoGenerationProvider + 'static
 {
 }
 
-/// When the durability feature flag is off, wrapping with `DurableVideo` is just a passthrough
+/// When the durability feature flag is off, `DurableVideo<Impl>` is a transparent wrapper that
+/// forwards every call to the inner provider without any oplog persistence.
 #[cfg(not(feature = "durability"))]
 mod passthrough_impl {
     use crate::durability::{DurableVideo, ExtendedVideoGenerationProvider};
     use crate::model::advanced::{
-        ExtendVideoOptions, GenerateVideoEffectsOptions, Guest as AdvancedGuest,
-        MultImageGenerationOptions,
+        ExtendVideoOptions, GenerateVideoEffectsOptions, MultImageGenerationOptions,
     };
-    use crate::model::lip_sync::Guest as LipSyncGuest;
     use crate::model::types::{
-        AudioSource, BaseVideo, EffectType, GenerationConfig, InputImage, Kv, LipSyncVideo,
-        MediaInput, VideoError, VideoResult, VoiceInfo,
+        AudioSource, BaseVideo, GenerationConfig, LipSyncVideo, MediaInput, VideoError,
+        VideoResult, VoiceInfo,
     };
-    use crate::model::video_generation::Guest as VideoGenerationGuest;
+    use crate::{AdvancedVideoGenerationProvider, LipSyncProvider, VideoGenerationProvider};
 
-    impl<Impl: ExtendedVideoGenerationProvider> VideoGenerationGuest for DurableVideo<Impl> {
+    impl<Impl: ExtendedVideoGenerationProvider> VideoGenerationProvider for DurableVideo<Impl> {
         fn generate(input: MediaInput, config: GenerationConfig) -> Result<String, VideoError> {
             Impl::generate(input, config)
         }
@@ -46,7 +41,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVideoGenerationProvider> LipSyncGuest for DurableVideo<Impl> {
+    impl<Impl: ExtendedVideoGenerationProvider> LipSyncProvider for DurableVideo<Impl> {
         fn generate_lip_sync(
             video: LipSyncVideo,
             audio: AudioSource,
@@ -59,7 +54,7 @@ mod passthrough_impl {
         }
     }
 
-    impl<Impl: ExtendedVideoGenerationProvider> AdvancedGuest for DurableVideo<Impl> {
+    impl<Impl: ExtendedVideoGenerationProvider> AdvancedVideoGenerationProvider for DurableVideo<Impl> {
         fn extend_video(options: ExtendVideoOptions) -> Result<String, VideoError> {
             Impl::extend_video(options)
         }


### PR DESCRIPTION
Followup to https://github.com/golemcloud/golem-ai/pull/123 and https://github.com/golemcloud/golem-ai/pull/124.

Fixes passthroughs across embed/exec/graph/search/tts/vector/video